### PR TITLE
Add additional sam3 dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,13 @@ protobuf>=3.20.2,<6.0.0
 #SAM2
 hydra-core>=1.3.0
 omegaconf>=2.3.0
-iopath>=0.1.9
 
 #SAM3
 decord
+timm>=1.0.17
+numpy==1.26
+tqdm
+ftfy==6.1.1
+regex
+iopath>=0.1.10
+typing_extensions


### PR DESCRIPTION
I added all dependencies in sam3. In my case, it didn't run properly because ftfy was missing.