### PR TITLE
feat: Add Apple Silicon (MPS) support

### DIFF
--- a/py/AILab_BiRefNet.py
+++ b/py/AILab_BiRefNet.py
@@ -22,7 +22,12 @@ import importlib.util
 from safetensors.torch import load_file
 import cv2
 
-device = "cuda" if torch.cuda.is_available() else "cpu"
+if torch.cuda.is_available():
+    device = "cuda"
+elif torch.backends.mps.is_available():
+    device = "mps"
+else:
+    device = "cpu"
 
 # Add model path
 folder_paths.add_model_folder_path("rmbg", os.path.join(folder_paths.models_dir, "RMBG"))

--- a/py/AILab_RMBG.py
+++ b/py/AILab_RMBG.py
@@ -31,7 +31,12 @@ from transformers import AutoModelForImageSegmentation
 import cv2
 import types
 
-device = "cuda" if torch.cuda.is_available() else "cpu"
+if torch.cuda.is_available():
+    device = "cuda"
+elif torch.backends.mps.is_available():
+    device = "mps"
+else:
+    device = "cpu"
 
 folder_paths.add_model_folder_path("rmbg", os.path.join(folder_paths.models_dir, "RMBG"))
 

--- a/requirements_mac.txt
+++ b/requirements_mac.txt
@@ -1,0 +1,18 @@
+# Base dependencies
+huggingface-hub>=0.19.0
+transparent-background>=1.1.2
+segment-anything>=1.0
+groundingdino-py>=0.4.0
+opencv-python>=4.7.0
+onnxruntime>=1.15.0
+protobuf>=3.20.2,<6.0.0
+
+#SAM2
+hydra-core>=1.3.0
+omegaconf>=2.3.0
+iopath>=0.1.9
+
+#SAM3
+ftfy
+typing_extensions
+


### PR DESCRIPTION
## Summary
This PR adds support for Apple Silicon Macs by enabling MPS (Metal Performance Shaders) device detection.
## Changes
- **Device detection**: Updated [AILab_BiRefNet.py](cci:7://file:///Users/jerry/code/ComfyUI-RMBG/AILab_BiRefNet.py:0:0-0:0) and [AILab_RMBG.py](cci:7://file:///Users/jerry/code/ComfyUI-RMBG/AILab_RMBG.py:0:0-0:0) to detect MPS device in addition to CUDA and CPU
- **Mac requirements**: Added [requirements_mac.txt](cci:7://file:///Users/jerry/code/ComfyUI-RMBG/requirements_mac.txt:0:0-0:0) with Mac-compatible dependencies (removed Windows-specific packages like `triton-windows` and `onnxruntime-gpu`)
## Testing
Tested on MacBook Pro with Apple Silicon (M-series chip).