### PR TITLE
Fix: Graceful fallback for torch.jit.script on AMD/ROCm

### DIFF
--- a/models/sam3/model/box_ops.py
+++ b/models/sam3/model/box_ops.py
@@ -142,7 +142,6 @@ def generalized_box_iou(boxes1, boxes2):
     return iou - (area - union) / area
 
 
-@torch.jit.script
 def fast_diag_generalized_box_iou(boxes1, boxes2):
     assert len(boxes1) == len(boxes2)
     box1_xy = boxes1[:, 2:]
@@ -168,8 +167,12 @@ def fast_diag_generalized_box_iou(boxes1, boxes2):
 
     return iou - (tot_area - union) / tot_area
 
+try:
+    fast_diag_generalized_box_iou = torch.jit.script(fast_diag_generalized_box_iou)
+except Exception:
+    pass
 
-@torch.jit.script
+
 def fast_diag_box_iou(boxes1, boxes2):
     assert len(boxes1) == len(boxes2)
     box1_xy = boxes1[:, 2:]
@@ -191,6 +194,12 @@ def fast_diag_box_iou(boxes1, boxes2):
     iou = inter / union
 
     return iou
+
+
+try:
+    fast_diag_box_iou = torch.jit.script(fast_diag_box_iou)
+except Exception:
+    pass
 
 
 def box_xywh_inter_union(


### PR DESCRIPTION
`@torch.jit.script` fails on AMD/ROCm backend due to incomplete TorchScript support. This replaces the decorators on `fast_diag_generalized_box_iou` and `fast_diag_box_iou` with a try/except block that attempts JIT compilation at import time and silently falls back to eager mode if it fails. 

Behavior on CUDA and CPU is unchanged.

Without this change, AMD/ROCm users encounter the following error:
```
Error loading C:\ComfyUI\custom_nodes\ComfyUI-RMBG\py\AILab_SAM3Segment.py: module 'torch.distributed' has no attribute 'rpc'
```

However, `torch.distributed.rpc` is actually available:
```
python -c "import torch; print(hasattr(torch.distributed, 'rpc'))"
True
```