### PR TITLE
Fix model loading crash with transformers 5.0.0

### DIFF
--- a/py/AILab_RMBG.py
+++ b/py/AILab_RMBG.py
@@ -187,6 +187,7 @@ class RMBGModel(BaseModelLoader):
 
                     module_name = f"custom_birefnet_model_{hash(birefnet_path)}"
                     module = types.ModuleType(module_name)
+                    module.__file__ = birefnet_path
                     sys.modules[module_name] = module
                     exec(birefnet_content, module.__dict__)
 


### PR DESCRIPTION
## Summary
- Set `__file__` attribute on dynamically created module in `RMBGModel.load_model()` to fix `AttributeError` with transformers 5.0.0
- Without this fix, `transformers.modeling_utils._can_set_experts_implementation()` crashes accessing `sys.modules[cls.__module__].__file__` on the module created via `types.ModuleType()`
- The fallback `from_pretrained()` path also fails due to meta tensor `.item()` calls during model initialization

## Reproduction
Using `transformers==5.0.0` + `torch==2.10.0`, loading any RMBG-2.0 model produces:
```
AttributeError: module 'custom_birefnet_model_...' has no attribute '__file__'
```

## Fix
One-line change: add `module.__file__ = birefnet_path` after `types.ModuleType()` creation (line 190).

## Test plan
- [x] Verified RMBG-2.0 model loads successfully with transformers 5.0.0
- [x] No impact on other model types (INSPYRENET, BEN, BEN2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)