### PR TITLE
fix: repaint COLORCODE widget swatch after picker change in Vue Node 2.0

### DIFF
--- a/web/js/colorWidget.js
+++ b/web/js/colorWidget.js
@@ -102,6 +102,7 @@ const AILabColorWidget = {
                     picker.addEventListener('change', () => {
                         this.value = picker.value;
                         node.graph._version++;
+                        this.callback?.(this.value);
                         node.setDirtyCanvas(true, true);
                         picker.remove();
                     });


### PR DESCRIPTION
Vue Node 2.0 renders this legacy custom widget on its own per-widget <canvas> via WidgetLegacy.vue, which wires widget.callback to call triggerDraw. Without it, node.setDirtyCanvas() only marks the litegraph canvas dirty and the Vue canvas keeps showing the old colour after the user picks a new one. Invoke this.callback?.(this.value) on the change event so triggerDraw repaints the Vue canvas; litegraph behaviour is unchanged because no callback is wired there.