### PR TITLE
Fix device selection on Apple Silicon (MPS)

### DIFF
--- a/py/AILab_BiRefNet.py
+++ b/py/AILab_BiRefNet.py
@@ -22,7 +22,8 @@ import importlib.util
 from safetensors.torch import load_file
 import cv2
 
-device = "cuda" if torch.cuda.is_available() else "cpu"
+from AILab_utils import get_device
+device = get_device()
 
 # Add model path
 folder_paths.add_model_folder_path("rmbg", os.path.join(folder_paths.models_dir, "RMBG"))

--- a/py/AILab_BodySegment.py
+++ b/py/AILab_BodySegment.py
@@ -45,7 +45,8 @@ def RGB2RGBA(image: Image.Image, mask: Union[Image.Image, torch.Tensor]) -> Imag
         mask = mask.resize(image.size, Image.Resampling.LANCZOS)
     return Image.merge('RGBA', (*image.convert('RGB').split(), mask.convert('L')))
 
-device = "cuda" if torch.cuda.is_available() else "cpu"
+from AILab_utils import get_device
+device = get_device()
 
 folder_paths.add_model_folder_path("rmbg", os.path.join(folder_paths.models_dir, "RMBG"))
 

--- a/py/AILab_ClothSegment.py
+++ b/py/AILab_ClothSegment.py
@@ -44,7 +44,8 @@ def RGB2RGBA(image: Image.Image, mask: Union[Image.Image, torch.Tensor]) -> Imag
         mask = mask.resize(image.size, Image.Resampling.LANCZOS)
     return Image.merge('RGBA', (*image.convert('RGB').split(), mask.convert('L')))
 
-device = "cuda" if torch.cuda.is_available() else "cpu"
+from AILab_utils import get_device
+device = get_device()
 
 folder_paths.add_model_folder_path("rmbg", os.path.join(folder_paths.models_dir, "RMBG"))
 

--- a/py/AILab_FaceSegment.py
+++ b/py/AILab_FaceSegment.py
@@ -42,7 +42,8 @@ def RGB2RGBA(image: Image.Image, mask: Union[Image.Image, torch.Tensor]) -> Imag
         mask = mask.resize(image.size, Image.Resampling.LANCZOS)
     return Image.merge('RGBA', (*image.convert('RGB').split(), mask.convert('L')))
 
-device = "cuda" if torch.cuda.is_available() else "cpu"
+from AILab_utils import get_device
+device = get_device()
 
 folder_paths.add_model_folder_path("rmbg", os.path.join(folder_paths.models_dir, "RMBG"))
 

--- a/py/AILab_FashionSegment.py
+++ b/py/AILab_FashionSegment.py
@@ -38,7 +38,8 @@ def mask2image(mask: torch.Tensor) -> Image.Image:
         mask = mask.unsqueeze(0)
     return tensor2pil(mask)
 
-device = "cuda" if torch.cuda.is_available() else "cpu"
+from AILab_utils import get_device
+device = get_device()
 
 folder_paths.add_model_folder_path("rmbg", os.path.join(folder_paths.models_dir, "RMBG"))
 

--- a/py/AILab_RMBG.py
+++ b/py/AILab_RMBG.py
@@ -31,7 +31,8 @@ from transformers import AutoModelForImageSegmentation
 import cv2
 import types
 
-device = "cuda" if torch.cuda.is_available() else "cpu"
+from AILab_utils import get_device
+device = get_device()
 
 folder_paths.add_model_folder_path("rmbg", os.path.join(folder_paths.models_dir, "RMBG"))
 

--- a/py/AILab_SegmentV2.py
+++ b/py/AILab_SegmentV2.py
@@ -15,6 +15,7 @@ from groundingdino.util import box_ops
 from transformers import AutoProcessor, AutoModelForZeroShotObjectDetection
 
 from AILab_ImageMaskTools import pil2tensor, tensor2pil
+from AILab_utils import get_device
 
 SAM_MODELS = {
     "sam_vit_h (2.56GB)": {
@@ -165,7 +166,7 @@ class SegmentV2:
     def segment_v2(self, image, prompt, sam_model, dino_model, threshold=0.30,
                    mask_blur=0, mask_offset=0, background="Alpha", 
                    background_color="#222222", invert_output=False):
-        device = "cuda" if torch.cuda.is_available() else "cpu"
+        device = get_device()
 
         batch_size = image.shape[0] if len(image.shape) == 4 else 1
         if len(image.shape) == 3:

--- a/py/AILab_utils.py
+++ b/py/AILab_utils.py
@@ -3,6 +3,17 @@ import numpy as np
 import torch
 from PIL import Image
 from comfy.utils import common_upscale
+import comfy.model_management as mm
+
+
+def get_device():
+    """Return the torch device ComfyUI selected (CUDA, MPS, or CPU).
+
+    Defers to ComfyUI's device management instead of assuming CUDA-or-CPU, so nodes
+    follow whatever backend ComfyUI chose. Fixes models silently running on CPU on
+    Apple Silicon (MPS). See issues #200 and #135.
+    """
+    return mm.get_torch_device()
 
 
 def tensor2pil(image: torch.Tensor) -> Image.Image:


### PR DESCRIPTION
## Summary

On Apple Silicon (Mac, MPS), several nodes selected their device with a module-level

```python
device = "cuda" if torch.cuda.is_available() else "cpu"
```

Since `torch.cuda.is_available()` is `False` on a Mac, they silently fell back to **CPU** even when ComfyUI itself had selected **MPS**. The model still runs, just far slower, so there's no error — only a job that sits at **0% for minutes**, which reads as a hang.

This defers device selection to ComfyUI's own device management via a small shared helper, so the nodes follow whatever backend ComfyUI chose (CUDA, MPS, or CPU) — the same approach the SAM2 / SAM3 / Florence2 / Segment / SDMatte nodes already use.

## Changes

- Add `get_device()` to `py/AILab_utils.py`, wrapping `comfy.model_management.get_torch_device()`.
- Use it in the nodes that hard-coded the CUDA-or-CPU check: **BiRefNet, RMBG, ClothSegment, BodySegment, FashionSegment, FaceSegment, SegmentV2**.
- Centralizing it in one helper keeps the check from drifting again.
- `LamaRemover` already uses `get_torch_device()` and is left unchanged.

`device` is only ever used as `.to(device)` / `map_location=device` / a hashable cache key, so returning a `torch.device` object instead of a string is safe at every call site.

## Evidence (before/after, Apple Silicon)

- Before (CPU fallback): a single BiRefNet image ≈ **18 min**.
- After (MPS): a 21-second video processed in ≈ **9 min** (~1s/frame).

Environment: Apple Silicon, macOS 15.7.4, 48 GB unified memory, ComfyUI 0.20.1 (Desktop), PyTorch 2.10.0, Python 3.13, ComfyUI-RMBG v3.0.0. ComfyUI startup correctly reports `Device: mps`.

## Notes

- A few ops may not yet be implemented for MPS. If you hit one, launch ComfyUI with `PYTORCH_ENABLE_MPS_FALLBACK=1` so those fall back to CPU instead of erroring.

## Related issues

- **Fixes #200** — "BiRefNet node stuck at 0% with no error on Mac Apple Silicon (ComfyUI Desktop)". This is exactly the reported symptom (BiRefNet stuck at 0% while RMBG-2.0 works on the same machine). The issue was auto-closed by the stale bot after 30 days of inactivity, not by a fix.
- **Related to #91** — "let user choose 'cuda' or 'cpu' as pytorch device", which first flagged this exact `device = "cuda" if torch.cuda.is_available() else "cpu"` pattern. A device dropdown was later added to the SAM2 node, but these image-segmentation nodes (BiRefNet, RMBG, Cloth/Body/Fashion/FaceSegment, SegmentV2) still hard-coded the CUDA-or-CPU check until now.
- **Related to #135** — SAM3 CPU/GPU device-selection crash; another data point that device handling has been a weak spot. (SAM3 already uses `get_torch_device()` and is unchanged here. Also closed for inactivity.)

If you'd prefer a user-facing device dropdown (Auto/CUDA/CPU/MPS) on these nodes — matching the YoloV8/SAM3 pattern — rather than this automatic deferral, happy to follow up with that.
